### PR TITLE
Package Spec Bugfix

### DIFF
--- a/NuGetPackageSpecs/UfoGame.nuspec
+++ b/NuGetPackageSpecs/UfoGame.nuspec
@@ -24,7 +24,7 @@
   <files>
     <file src="..\UfoGame\Source\Code\CorePlugin\bin\Debug\UfoGame.Sample.core.dll" target="lib" />
     <file src="..\UfoGame\Data\**\*.res" target="content" />
-    <file src="..\UfoGame\Source\**\*.cs" target="source" exclude="..\..\UfoGame\Data\**\*.*;..\UfoGame\Source\Code\CorePlugin\obj\**\*.*" />
+    <file src="..\UfoGame\Source\Code\CorePlugin\**\*.cs" target="source" exclude="..\..\UfoGame\Data\**\*.*;..\UfoGame\Source\Code\CorePlugin\obj\**\*.*" />
     <file src="..\UfoGame\Source\Code\CorePlugin\CorePlugin.csproj" target="source" />
   </files>
 </package>


### PR DESCRIPTION
In the current release, the source code is included, but it still carries the `\Code\CorePlugin` folder structure, which leads to `CorePlugin.csproj` not being able to locate its source files and failing to build. This change should hopefully address the issue in the next NuGet release of this package.